### PR TITLE
Encode description in UTF-8 instead of ASCII.

### DIFF
--- a/gh-mirror
+++ b/gh-mirror
@@ -97,7 +97,7 @@ def update_description(description_file, description):
     """
 
     with open(description_file, "w") as f:
-        f.write(description + "\n")
+        f.write(description.encode("utf8") + "\n")
 
 
 def update_or_mirror_repos(user):


### PR DESCRIPTION
Threw an exception if description contained non-ASCII characters.
