### PR TITLE
Use the clone_url instead of git_url

### DIFF
--- a/gh-mirror
+++ b/gh-mirror
@@ -40,7 +40,7 @@ def repos(user):
             break
 
         for repo in res_json:
-            yield {"description": repo["description"], "url": repo["git_url"]}
+            yield {"description": repo["description"], "url": repo["clone_url"]}
 
 
 def repo_already_mirrored(url):


### PR DESCRIPTION
git_url uses the git:// protocol which is phased out by GitHub (for unauthenticated users)